### PR TITLE
replace whitelist with allowlist

### DIFF
--- a/wasm3-sys/build.rs
+++ b/wasm3-sys/build.rs
@@ -40,11 +40,11 @@ fn gen_bindings() {
         .arg("--no-layout-tests")
         .arg("--default-enum-style=moduleconsts")
         .arg("--no-doc-comments")
-        .arg("--whitelist-function")
+        .arg("--allowlist-function")
         .arg(WHITELIST_REGEX_FUNCTION)
-        .arg("--whitelist-type")
+        .arg("--allowlist-type")
         .arg(WHITELIST_REGEX_TYPE)
-        .arg("--whitelist-var")
+        .arg("--allowlist-var")
         .arg(WHITELIST_REGEX_VAR)
         .arg("--no-derive-debug");
     for &ty in PRIMITIVES.iter() {


### PR DESCRIPTION
Whitelist args were removed in 0.63, we are using 0.59 but this somehow causes failures on windows.

I also fixed this upstream in https://github.com/wasm3/wasm3-rs/pull/46.